### PR TITLE
refactor: replace print statements with logging across the codebase

### DIFF
--- a/src/environment/pyEnvLibEnvironmentRepositoryImpl.py
+++ b/src/environment/pyEnvLibEnvironmentRepositoryImpl.py
@@ -1,5 +1,7 @@
+import os
 import random
 import time
+import logging
 from typing import Any, Optional
 
 from src.lib.pyenvlib.environment import Environment
@@ -13,11 +15,14 @@ from src.snake.snakePartRepository import SnakePartRepository
 
 from src.lib.pyenvlib.location import Location
 
+log_level = os.environ.get('LOG_LEVEL', 'INFO').upper()
+logging.basicConfig(level=getattr(logging, log_level))
+logger = logging.getLogger(__name__)
 
 class PyEnvLibEnvironmentRepositoryImpl(EnvironmentRepository):
     def __init__(self, level: int, grid_size: int, snake_part_repository: SnakePartRepository, config: Config) -> None:
         self.config = config
-        print("Initializing environment repository for level " + str(level) + " with grid size " + str(grid_size))
+        logging.info("Initializing environment repository for level " + str(level) + " with grid size " + str(grid_size))
         if level == 1:
             self.environment = Environment(
                 "Level " + str(level), grid_size
@@ -181,7 +186,7 @@ class PyEnvLibEnvironmentRepositoryImpl(EnvironmentRepository):
         elif direction == 3:
             new_location = self.get_location_right_of_entity(entity)
         else:
-            print("Error: Invalid direction specified for entity movement.")
+            logging.error("Error: Invalid direction specified for entity movement.")
             raise ValueError("Invalid direction specified for entity movement.")
 
         if new_location == -1:
@@ -191,7 +196,7 @@ class PyEnvLibEnvironmentRepositoryImpl(EnvironmentRepository):
             e = new_location.getEntity(eid)
             if type(e) is SnakePart:
                 self.collision = True
-                print("The ophidian collides with itself and ceases to be.")
+                logging.info("The ophidian collides with itself and ceases to be.")
                 time.sleep(self.config.tick_speed * 20)
                 if self.config.restart_upon_collision:
                     check_for_level_progress_and_reinitialize = True
@@ -226,7 +231,7 @@ class PyEnvLibEnvironmentRepositoryImpl(EnvironmentRepository):
         previous_snake_part_location = self.get_location_of_entity(previous_snake_part)
 
         if previous_snake_part_location == -1:
-            print("Error: A previous snake part's location was unexpectantly -1.")
+            logging.error("Error: A previous snake part's location was unexpectantly -1.")
 
         target_location = snake_part.lastPosition
 

--- a/src/ophidian.py
+++ b/src/ophidian.py
@@ -1,5 +1,7 @@
+import os
 import random
 import time
+import logging
 
 import pygame
 
@@ -12,6 +14,9 @@ from src.environment.pyEnvLibEnvironmentRepositoryImpl import PyEnvLibEnvironmen
 from src.score.game_score import GameScore
 from src.state.game_state_repository import GameStateRepository
 
+log_level = os.environ.get('LOG_LEVEL', 'INFO').upper()
+logging.basicConfig(level=getattr(logging, log_level))
+logger = logging.getLogger(__name__)
 
 # @author Daniel McCoy Stephenson
 # @since August 6th, 2022
@@ -72,13 +77,13 @@ class Ophidian:
         self.state_repository.save(state)
 
     def check_for_level_progress_and_reinitialize(self):
-        print("Checking for level progress...")
+        logging.info("Checking for level progress...")
         if (
                 self.snake_part_repository.get_length()
                 > self.environment_repository.get_num_locations()
                 * self.config.level_progress_percentage_required
         ):
-            print("The ophidian has progressed to the next level.")
+            logging.info("The ophidian has progressed to the next level.")
             self.game_score.level_complete()
             self.level += 1
             should_increase_grid_size = True
@@ -89,11 +94,11 @@ class Ophidian:
 
         self.save_game_state()
 
-        print("Reinitializing the environment...")
+        logging.info("Reinitializing the environment...")
         self.environment_repository.reinitialize(self.level, should_increase_grid_size)
-        print("Clearing the environment repository")
+        logging.info("Clearing the environment repository")
         self.environment_repository.clear()
-        print("Re-initializing the game")
+        logging.info("Re-initializing the game")
         self.initialize()
 
     def quit_application(self):
@@ -108,17 +113,17 @@ class Ophidian:
         )
         result = key_down_event_handler.handle_key_down_event(key)
         if result == "quit":
-            print("Quiting the application...")
+            logging.info("Quiting the application...")
             self.quit_application()
             return None
         elif result == "restart":
-            print("Restarting the game...")
+            logging.info("Restarting the game...")
             # Reset score when manually restarting
             self.game_score.reset()
             self.check_for_level_progress_and_reinitialize()
             return "restart"
         elif result == "initialize game display":
-            print("Re-initializing the game display...")
+            logging.info("Re-initializing the game display...")
             self.renderer.initialize_game_display()
             return None
         return None
@@ -137,7 +142,7 @@ class Ophidian:
         )
         self.environment_repository.add_entity_to_random_location(self.selected_snake_part)
         self.snake_part_repository.append(self.selected_snake_part)
-        print("The ophidian enters the world.")
+        logging.info("The ophidian enters the world.")
         self.environment_repository.spawn_food()
 
 

--- a/src/score/game_score.py
+++ b/src/score/game_score.py
@@ -1,3 +1,9 @@
+import logging
+import os
+
+log_level = os.environ.get('LOG_LEVEL', 'INFO').upper()
+logging.basicConfig(level=getattr(logging, log_level))
+logger = logging.getLogger(__name__)
 
 class GameScore:
     def __init__(self, snake_part_repository, environment_repository):
@@ -17,16 +23,11 @@ class GameScore:
         length = self.snake_part_repository.get_length()
         num_locations = self.environment_repository.get_num_locations()
         percentage = int(length / num_locations * 100)
-        print(
-            "The ophidian had a length of",
-            length,
-            "and took up",
-            percentage,
-            "percent of the world.",
-        )
-        print("Level Score:", self.current_points)
-        print("Total Score:", self.cumulative_points)
-        print("-----")
+        logging.info("The ophidian had a length of %d", length)
+        logging.info("The ophidian took up %d percent of the world", percentage)
+        logging.info("Level Score: %d", self.current_points)
+        logging.info("Total Score: %d", self.cumulative_points)
+        logging.info("-----")
 
     def reset(self):
         self.current_points = 0

--- a/src/state/game_state_repository.py
+++ b/src/state/game_state_repository.py
@@ -1,7 +1,14 @@
 import json
+import logging
+import os
+
 from pathlib import Path
 
 from .game_state import GameState
+
+log_level = os.environ.get('LOG_LEVEL', 'INFO').upper()
+logging.basicConfig(level=getattr(logging, log_level))
+logger = logging.getLogger(__name__)
 
 
 class GameStateRepository:
@@ -14,7 +21,7 @@ class GameStateRepository:
             with open(self.file_path, 'w') as f:
                 json.dump(game_state, f)
         except IOError as e:
-            print(f"Could not save game state: {e}")
+            logging.error(f"Could not save game state: {e}")
 
     def load(self):
         """Load game state from JSON file"""
@@ -25,5 +32,5 @@ class GameStateRepository:
                     return GameState.from_dict(data)
             return GameState()  # Return default state if file doesn't exist
         except IOError as e:
-            print(f"Could not load game state: {e}")
+            logging.error(f"Could not load game state: {e}")
             return GameState()  # Return default state on error


### PR DESCRIPTION
- Replaced `print` statements with `logging` to improve flexibility and debugging.
- Configured logging to use environment-variable-driven log levels.
- Applied changes consistently across all files to standardize logging practices.